### PR TITLE
Add create second ELK and Kibana

### DIFF
--- a/logging/Create-Second-ELK-and-Kibana/README.md
+++ b/logging/Create-Second-ELK-and-Kibana/README.md
@@ -1,0 +1,230 @@
+# Installing a second ELK-Stack and Kibana Dashboard
+
+The reasons for installing a second ELK stack and Kibana dashboard are:
+
+- Keeping the application logs from custom namespaces separate from the logs from kube-system namespace
+- Configure 14 days (different time) before cleaning up application logs in ELK. The kube-system logs are cleaned after 1 day.
+
+ELK
+
+- A custom ELK stack installation collects logfiles from custom namespaces (filebeat configuration)
+- Logstash uploads logfiles into separate elasicsearch database
+- Database stored in own Persistent Volumens
+
+Kibana
+
+- A custom Kibana dashboard is configured to show logs only from custom ELK stack
+  - https://icp-master:8443/kibana-apps
+
+# Installation Steps
+
+Overview ELK stack installation steps
+- Create persistance volumen and Filesystem /var/lib/appelk on Management Nodes.
+- Create helm chart values.yaml
+- Install helm chart ibm-icplogging from IBM charts https://github.com/IBM/charts.git
+- Modify filebeat ConfigMap to collect logs from namespace.
+
+Overview Kibana installation steps
+- Create helm chart values.yaml
+- Install helm chart ibm-icplogging-kibana from IBM charts https://github.com/IBM/charts.git
+- Modify ConfigMap and change server.basePath: "/kibana" to : "/kibana-apps" 
+- Restart/delete pod kibana.
+
+# Download ICP Helm Charts
+
+Download ICP Helm charts from git repository
+
+    git clone https://github.com/IBM/charts.git
+
+If offline without internet access, then download master.zip and copy to a client with access to ICP
+
+    wget https://github.com/IBM/charts/archive/master.zip
+
+# Install ELK Helm Chart
+
+## Prepare ELK Helm chart values.yaml
+
+Copy values.yaml from charts/stable/ibm-icplogging and modify
+
+Append `-apps` to names
+
+    name: logstash-apps
+    name: filebeat-apps
+    name: "elasticsearch-apps"
+    name: client-apps
+    name: master-apps
+
+Set kibana install to false. We install Kibana from separate helm chart ibm-icplogging-kibana
+install: false
+
+Set filebeat configuration to collect logs from namespaces
+
+    namespace-apps-a-*
+    namespace-apps-b-*
+    namespace-apps-c-*
+
+Set mode managed. This ensures that elk stack pods are running on Management Nodes
+
+    mode: managed
+
+## Summary ELK Stack values.yaml
+
+The following changes are made to values.yaml file. Other entries remain on their default value.
+
+```
+logstash: 
+    name: logstash-apps
+kibana: 
+  install: false 
+filebeat:
+  name: filebeat-apps 
+      - namespapce-apps-a*  
+      - namespace-apps-b* 
+elasticsearch:
+  name: "elasticsearch-apps"  
+  internalPort: 9301 
+    name: client-apps  
+    restPort: 9201  
+    name: master-apps    
+    replicas: 2 
+    name: data-apps 
+      size: 100Gi   
+      storageClass: "logging-storage-datanode"
+...
+mode: managed   # Pods are running on Management Node
+```
+
+## Create Persistent Volume
+
+Create filesystem /var/lib/appelk with 100 GB on Mgmt Nodes
+Create a Persistent Volume for each Management Node
+
+```
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: data-elk-apps-name-ibm-icplogging-data-apps-0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 100Gi
+  local:
+    path: /var/lib/appelk
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - 10.125.1.16  # Use Management Node IP
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: logging-storage-datanode
+```
+
+##  Running helm install
+
+Install elk helm chart from command line
+
+```
+helm install --name elk-icp-apps charts/stable/ibm-icplogging  --namespace kube-system –f values.yaml --tls 
+ 
+
+helm ls elk-icp-apps --tls
+NAME            REVISION        UPDATED                         STATUS          CHART                   NAMESPACE
+elk-icp-apps    1               Thu Sep 13 09:40:12 2018        DEPLOYED        ibm-icplogging-1.0.1    kube-system
+```
+
+## ConfigMap filebeat configures the namespaces to collect logfiles from
+
+Add filter (regex) to collect logs only from certain namespaces 
+
+    kubectl edit cm -n kube-system elk-icp-apps-ibm-icplogging-filebeat-apps-config
+
+Add or modify paths in ConfigMap to filter namespaces
+
+    paths:
+        - "/var/log/containers/*_namespace-apps-a-*_*.log"
+        - "/var/log/containers/*_namespace-apps-b-*_*.log"
+        - "/var/log/containers/*_namespace-apps-c-*_*.log“
+
+Restart filebeat Pods
+
+    kubectl get pod -n kube-system -l release=elk-icp-apps
+    kubectl delete pod -n kube-system ...(filebeat pods)
+
+## ConfigMap curator to cleanup  indices
+
+The curator cleans old indices from elastic search. The default is 1 day. 
+The requirement is to retain application logs for 14 days.
+
+Edit curator ConfigMap
+
+    kubectl edit cm -n kube-system elk-icp-apps-ibm-icplogging-elasticsearch-apps-curator-config -o yaml
+
+Change unit_count from 1 to 14
+
+       unit_count: 14
+
+Restart elk client pod 
+
+    kubectl get -n kube-system pod | grep client
+
+    kubectl -n kube-system delete pod elk-icp-apps-ibm-icplogging-client-apps-675c4d7dcd-hk7mv
+
+
+# Install Kibana
+
+## Prepare Kibana Helm Chart values.yaml
+
+Copy values.yaml from charts/stable/ibm-icplogging-kibana/ and modify
+
+```
+elasticsearch:
+  service:
+    name: elasticsearch-apps                                 
+    port: 9201                                               
+
+kibana:
+  name: kibana-apps                                         
+  managedMode: true     # Pods are running on Management Node
+````
+
+## Running helm install
+
+``` 
+helm install --name kibana-icp-apps charts/stable/ibm-icplogging-kibana/ -f values.yaml --namespace kube-system –tls
+
+helm ls kibana-icp-apps --tls
+NAME            REVISION        UPDATED                         STATUS          CHART                           NAMESPACE
+kibana-icp-apps 1               Wed Sep 12 14:51:32 2018        DEPLOYED        ibm-icplogging-kibana-1.0.0     kube-system 
+```
+
+## Modify Kibana Ingress and ConfigMap
+
+Edit Ingress and change path from /kibana to /kibana-apps
+
+    kubectl edit -n kube-system ingress kibana-icp-apps-ibm-icplogging-kibana-ingress
+
+     path: /kibana-apps
+
+Edit ConfigMap and change server.basePath to "/kibana-apps"
+
+    kubectl edit cm -n kube-system kibana-icp-apps-ibm-icplogging-kibana-config
+
+    server.basePath: "/kibana-apps"
+
+Restart Kibana Pod
+
+    kubectl get pod -n kube-system -l release=kibana-icp-apps
+    kubectl delete pod -n kube-system kibana-icp-apps-ibm-icplogging-kibana-5fc8f89c9-nwjbn
+
+# Summary
+
+A second elasticsearch has been deployed
+
+A second kibana dashboard has been deployed and configured to use the new elasticsearch 
+  -  https://icp-master:8443/kibana-apps
+
+

--- a/logging/Create-Second-ELK-and-Kibana/pv-elk.yaml
+++ b/logging/Create-Second-ELK-and-Kibana/pv-elk.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: data-elk-apps-name-ibm-icplogging-data-apps-0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 100Gi
+  local:
+    path: /var/lib/appelk
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - 10.125.1.16
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: logging-storage-datanode

--- a/logging/Create-Second-ELK-and-Kibana/values-elk.yaml
+++ b/logging/Create-Second-ELK-and-Kibana/values-elk.yaml
@@ -1,0 +1,165 @@
+# Licensed Materials - Property of IBM
+# 5737-E67
+# @ Copyright IBM Corporation 2016, 2018. All Rights Reserved.
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+image:
+  pullPolicy: IfNotPresent
+
+security:
+  # Security can be flagged on for any platform, but will only work on x86 nodes.
+  enabled: false
+  provider: searchguard-tls
+  ca:
+    keystore:
+      password: changeme
+    truststore:
+      password: changeme
+    # set to `external` to use existing CA stored in Kubernetes secret to generate certs
+    origin: internal
+    external:
+      # the secret need to be in the same namespace as the chart release
+      secretName: cluster-ca-cert
+      # the Kubenetes field name (key) within the specified secret that stores CA cert
+      certFieldName: tls.crt
+      # the Kubenets field name (key) within the specified secret that stores CA private key
+      keyFieldName: tls.key
+  app:
+    keystore:
+      password: changeme
+
+logstash:
+  replicas: 1
+  name: logstash-apps
+  heapSize: "512m"
+  memoryLimit: "1024Mi"
+  port: 5000
+  image:
+    repository: "ibmcom/logstash"
+    tag: "5.5.1"
+  probe:
+    enabled: false
+    periodSeconds: 60
+    minEventsPerPeriod: 1
+    maxUnavailablePeriod: 5
+    image:
+      repository: "ibmcom/logstash-liveness-probe"
+      tag: "0.1.8"
+
+kibana:
+  install: false
+  replicas: 1
+  name: kibana-apps
+  internal: 5601
+  external: 31601
+  # maximum old space size (in MB) of the V8 Javascript engine
+  maxOldSpaceSize: "1024"
+  memoryLimit: "1280Mi"
+  image:
+    repository: ibmcom/kibana
+    tag: 5.5.1
+  initImage:
+    repository: "ibmcom/curl"
+    tag: "3.6"
+  routerImage:
+    repository: "ibmcom/icp-router"
+    tag: "2.2.0"
+
+filebeat:
+  name: filebeat-apps
+  image:
+    repository: "ibmcom/filebeat"
+    tag: 5.5.1
+  scope:
+    nodes:
+    namespaces:
+      - namespace-a-*
+      - namespace-b-*
+
+elasticsearch:
+  name: "elasticsearch-apps"
+  internalPort: 9301
+  image:
+    repository: "ibmcom/elasticsearch"
+    tag: "5.5.1"
+  pluginImage:
+    repository: "ibmcom/elasticsearch-plugin-searchguard"
+    tag: "1.0.0"
+  pluginInitImage:
+    repository: "ibmcom/searchguard-init"
+    tag: "1.0.0"
+  pkiInitImage:
+    repository: "ibmcom/logging-pki-init"
+    tag: "1.3.0"
+  initImage:
+    repository: "ibmcom/icp-initcontainer"
+    tag: "1.0.0"
+
+  client:
+    name: client-apps
+    replicas: 1
+    heapSize: "1024m"
+    memoryLimit: "1536Mi"
+    restPort: 9201
+    antiAffinity: soft
+
+  master:
+    name: master-apps
+    # Set to the # of management (or master, if no mgmt) nodes
+    replicas: 2
+    heapSize: "1024m"
+    memoryLimit: "1536Mi"
+    antiAffinity: soft
+
+  data:
+    name: data-apps
+    # Set to the # of management (or master, if no mgmt) nodes
+    replicas: 2
+    heapSize: "1024m"
+    memoryLimit: "2048M"
+    antiAffinity: hard
+    storage:
+      # When true will expect a PersistentVolume
+      persistent: true
+      # Set to true if you are using GlusterFS or other dynamic provisioner
+      useDynamicProvisioning: false
+      # If not using dynamic provisioning, you can use selectors to refine the binding process.
+      # These are IGNORED if using dynamic provisioning.
+      selector:
+        label: ""
+        value: ""
+      # 10Gi is not the recommended size, but rather a small default.
+      # It will match much larger drives as well.
+      size: 100Gi
+      accessModes:
+        - ReadWriteOnce
+      ## Specify the storageClass name you want to use
+      ## If you don't specify a storageClass name it will use the default
+      storageClass: "logging-storage-datanode"
+
+curator:
+  name: log-curator
+  image:
+    repository: "ibmcom/indices-cleaner"
+    tag: 0.2
+  # runs at 23:30 UTC daily
+  schedule: "30 23 * * *"
+  app:
+    unit: days
+    count: 1
+  monitoring:
+    unit: days
+    count: 1
+  watcher:
+    unit: days
+    count: 1
+
+mode: managed
+
+xpack:
+  # Must be false for PPC, otherwise the log is spammed with errors
+  monitoring: false
+  graph: false
+  reporting: false
+  ml: false
+  watcher: false

--- a/logging/Create-Second-ELK-and-Kibana/values-kibana.yaml
+++ b/logging/Create-Second-ELK-and-Kibana/values-kibana.yaml
@@ -1,0 +1,39 @@
+# Licensed Materials - Property of IBM
+# 5737-E67
+# @ Copyright IBM Corporation 2016, 2018. All Rights Reserved.
+# US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+
+image:
+  pullPolicy: IfNotPresent
+
+elasticsearch:
+  service:
+    name: elasticsearch-apps
+    port: 9201
+  security:
+    # Should only be true when target Elasticsearch cluster is also secured
+    enabled: false
+    # This is the default for managed ELK; expands to -certs and -elasticsearch-pki-secret for target credentials
+    secretRoot: logging-elk
+
+kibana:
+  replicas: 1
+  name: kibana-apps
+  internal: 5601
+  external: 32601
+  # maximum old space size (in MB) of the V8 Javascript engine
+  maxOldSpaceSize: "1024"
+  memoryLimit: "1280Mi"
+  image:
+    repository: ibmcom/kibana
+    tag: 5.5.1
+  routerImage:
+    repository: "ibmcom/icp-router"
+    tag: "2.2.0"
+  managedMode: true
+
+xpack:
+  monitoring: false
+  graph: false
+  reporting: false
+  ml: false


### PR DESCRIPTION
Adding steps to create a second ELK stack and Kibana dashboard that exist side by side with the existing ELK and Kibana installed by ICP.

This is useful 
- If log-files from application namespaces need to be stored for a longer time that the default 1 day before cleaned from ELK.
- if log-files from a subset of namespaces should be collected and stored separately from kube-system logs.