### PR TITLE
improve apiserver alert rule

### DIFF
--- a/prometheus/alerts_icp_2.1.0.2-3.1.1/alert-rules-icp311.yaml
+++ b/prometheus/alerts_icp_2.1.0.2-3.1.1/alert-rules-icp311.yaml
@@ -244,8 +244,7 @@ data:
             disappeared from service discovery.
           summary: API server unreachable
       - alert: ICPApiServerLatency
-        expr: histogram_quantile(0.99, sum without(instance, resource) (apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST|WATCH|PROXY"}))
-          / 1e+06 > 1
+        expr: histogram_quantile(0.99, sum by(le) (rate(apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST|WATCH|PROXY"}[10m]))) / 1e+06 > 1
         for: 10m
         labels:
           severity: warning


### PR DESCRIPTION
*_buckets are cumulative. Then if the alert fired at some time, it will keep alert
consistently. It should be evaluated with the changing ratio within some time. le is
a common label for all the buckets, this should be enough for this computing.

Signed-off-by: dongdwdw <dongdwdw@cn.ibm.com>